### PR TITLE
fix: respect --data-dir CLI option in GemfileVersion#data_dir

### DIFF
--- a/lib/mnenv/models/gemfile_version.rb
+++ b/lib/mnenv/models/gemfile_version.rb
@@ -28,7 +28,14 @@ module Mnenv
     end
 
     def data_dir
-      @data_dir ||= File.join(self.class.versions_manager.data_path, 'gemfile')
+      @data_dir ||= begin
+        base_dir = if defined?(Mnenv::Cli) && Mnenv::Cli.data_dir
+                     Mnenv::Cli.data_dir
+                   else
+                     self.class.versions_manager.data_path
+                   end
+        File.join(base_dir, 'gemfile')
+      end
     end
 
     def directory_path = File.join(data_dir, "v#{version}")


### PR DESCRIPTION
## Problem

`GemfileVersion#data_dir` always resolved to `~/.mnenv/versions/data/gemfile/`, ignoring the `--data-dir` CLI option passed to `mnenv gemfile --data-dir=PATH refresh`.

This caused the CI workflow in `metanorma/versions` to:
1. Extract `Gemfile`/`Gemfile.lock.archived` files to `~/.mnenv/versions/data/gemfile/` (wrong path)
2. Write `versions.yaml` to `$PWD/data/gemfile/` (correct path, via Repository)
3. Result: automated PRs only contain the YAML change, not the actual extracted files

## Fix

Check `Mnenv::Cli.data_dir` first before falling back to `versions_manager.data_path`. This mirrors the existing pattern in `Repository#cli_data_dir`.

## Testing

Existing specs pass. The fix is minimal and only changes the resolution order of the data directory path.

Fixes metanorma/versions#26